### PR TITLE
[#6] Setup wagtail for our project

### DIFF
--- a/dezentrale_web/apps/wagtail_search/templates/search/search.html
+++ b/dezentrale_web/apps/wagtail_search/templates/search/search.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+{% load static wagtailcore_tags %}
+
+{% block body_class %}template-searchresults{% endblock %}
+
+{% block title %}Search{% endblock %}
+
+{% block content %}
+    <h1>Search</h1>
+
+    <form action="{% url 'search' %}" method="get">
+        <input type="text" name="query"{% if search_query %} value="{{ search_query }}"{% endif %}>
+        <input type="submit" value="Search" class="button">
+    </form>
+
+    {% if search_results %}
+        <ul>
+            {% for result in search_results %}
+                <li>
+                    <h4><a href="{% pageurl result %}">{{ result }}</a></h4>
+                    {% if result.search_description %}
+                        {{ result.search_description }}
+                    {% endif %}
+                </li>
+            {% endfor %}
+        </ul>
+
+        {% if search_results.has_previous %}
+            <a href="{% url 'search' %}?query={{ search_query|urlencode }}&amp;page={{ search_results.previous_page_number }}">Previous</a>
+        {% endif %}
+
+        {% if search_results.has_next %}
+            <a href="{% url 'search' %}?query={{ search_query|urlencode }}&amp;page={{ search_results.next_page_number }}">Next</a>
+        {% endif %}
+    {% elif search_query %}
+        No results found
+    {% endif %}
+{% endblock %}

--- a/dezentrale_web/apps/wagtail_search/views.py
+++ b/dezentrale_web/apps/wagtail_search/views.py
@@ -1,0 +1,36 @@
+from __future__ import absolute_import, unicode_literals
+
+from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
+from django.shortcuts import render
+
+from wagtail.wagtailcore.models import Page
+from wagtail.wagtailsearch.models import Query
+
+
+def search(request):
+    search_query = request.GET.get('query', None)
+    page = request.GET.get('page', 1)
+
+    # Search
+    if search_query:
+        search_results = Page.objects.live().search(search_query)
+        query = Query.get(search_query)
+
+        # Record hit
+        query.add_hit()
+    else:
+        search_results = Page.objects.none()
+
+    # Pagination
+    paginator = Paginator(search_results, 10)
+    try:
+        search_results = paginator.page(page)
+    except PageNotAnInteger:
+        search_results = paginator.page(1)
+    except EmptyPage:
+        search_results = paginator.page(paginator.num_pages)
+
+    return render(request, 'search/search.html', {
+        'search_query': search_query,
+        'search_results': search_results,
+    })

--- a/dezentrale_web/config/settings/common.py
+++ b/dezentrale_web/config/settings/common.py
@@ -128,17 +128,6 @@ class Common(Configuration):
         #    'django.contrib.staticfiles.finders.DefaultStorageFinder',
     ])
 
-    MIDDLEWARE_CLASSES = values.ListValue([
-        'django.contrib.sessions.middleware.SessionMiddleware',
-        'django.middleware.common.CommonMiddleware',
-        'django.middleware.csrf.CsrfViewMiddleware',
-        'django.contrib.auth.middleware.AuthenticationMiddleware',
-        'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
-        'django.contrib.messages.middleware.MessageMiddleware',
-        'django.middleware.clickjacking.XFrameOptionsMiddleware',
-        'django.middleware.security.SecurityMiddleware',
-    ])
-
     ROOT_URLCONF = 'dezentrale_web.config.urls'
 
     WSGI_APPLICATION = 'dezentrale_web.config.wsgi.application'
@@ -177,7 +166,41 @@ class Common(Configuration):
         os.path.join(BaseDir.BASE_DIR, 'fixtures'),
     )
 
+    MIDDLEWARE = [
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.middleware.common.CommonMiddleware',
+        'django.middleware.csrf.CsrfViewMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+        'django.contrib.messages.middleware.MessageMiddleware',
+        'django.middleware.clickjacking.XFrameOptionsMiddleware',
+        'django.middleware.security.SecurityMiddleware',
+
+        'wagtail.wagtailcore.middleware.SiteMiddleware',
+        'wagtail.wagtailredirects.middleware.RedirectMiddleware',
+    ]
+
     INSTALLED_APPS = (
+        # Custom
+        'dezentrale_web.apps.wagtail_search',
+
+        # Wagtail
+        'wagtail.wagtailforms',
+        'wagtail.wagtailredirects',
+        'wagtail.wagtailembeds',
+        'wagtail.wagtailsites',
+        'wagtail.wagtailusers',
+        'wagtail.wagtailsnippets',
+        'wagtail.wagtaildocs',
+        'wagtail.wagtailimages',
+        'wagtail.wagtailsearch',
+        'wagtail.wagtailadmin',
+        'wagtail.wagtailcore',
+
+        'modelcluster',
+        'taggit',
+
+        # Regular Django
         'django.contrib.auth',
         'django.contrib.contenttypes',
         'django.contrib.sessions',
@@ -189,6 +212,7 @@ class Common(Configuration):
         'django.contrib.admindocs',
         'crispy_forms',
         'rules.apps.AutodiscoverRulesConfig',
+
     )
 
     CACHES = values. DictValue({
@@ -206,3 +230,6 @@ class Common(Configuration):
     DEFAULT_FROM_EMAIL = values.EmailValue('wladi.schneider13@googlemail.com')
 
     SERVER_EMAIL = DEFAULT_FROM_EMAIL
+
+    # Wagtail settings
+    WAGTAIL_SITE_NAME = "dezentrale.space"

--- a/dezentrale_web/config/settings/public.py
+++ b/dezentrale_web/config/settings/public.py
@@ -18,9 +18,9 @@ class Raven(object):
 class Sentry404(Raven):
     """Log 404 events to the Sentry server."""
 
-    MIDDLEWARE_CLASSES = values.ListValue([
+    MIDDLEWARE = values.ListValue([
         'raven.contrib.django.raven_compat.middleware.Sentry404CatchMiddleware',
-    ].append(common.Common.MIDDLEWARE_CLASSES))
+    ].append(common.Common.MIDDLEWARE))
 
 
 class Public(email.Email, databases.Databases, common.Common):

--- a/dezentrale_web/config/urls.py
+++ b/dezentrale_web/config/urls.py
@@ -4,7 +4,21 @@ from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.contrib import admin
 
+from wagtail.wagtailadmin import urls as wagtailadmin_urls
+from wagtail.wagtailcore import urls as wagtail_urls
+from wagtail.wagtaildocs import urls as wagtaildocs_urls
+
+from dezentrale_web.apps.wagtail_search import views as search_views
+
 urlpatterns = [
     url(r'^grappelli/', include('grappelli.urls')),
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^django-admin/', include(admin.site.urls)),
+    # Wagtail
+    url(r'^admin/', include(wagtailadmin_urls)),
+    url(r'^documents/', include(wagtaildocs_urls)),
+    url(r'^search/$', search_views.search, name='search'),
+    # For anything not caught by a more specific rule above, hand over to
+    # Wagtail's page serving mechanism. This should be the last pattern in
+    # the list:
+    url(r'', include(wagtail_urls)),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ requires = [
     'django-crispy-forms==1.5.2',
     'django-grappelli==2.7.2',
     'django-model-utils==2.4',
+    'wagtail==1.11.1',
     'envdir==0.7',
     'psycopg2==2.6.1',
     'pytz==2015.7',


### PR DESCRIPTION
We do not use the default wagtail project layout. Instead we integrate relevant parts into our own structure. For this we use the default wagtail search app under a different name and adjust the url patterns accordingly.

We also include a huge set of wagtail apps in ``INSTALLED_APP`` for now. At some later stage we should evaluate whether we actually need al of those or not.

We also use the opportunity to change (the outdated) ``common.MIDDLEWARE_CLASSES`` to ``common.MIDDLEWARE``.

In order to test this do the following:
1. set up a fresh environment
2. checkout this branch
3. run ``make migrate`` -> a lot of output should show up on your TTY
4. create a ``superuser``
5 ``make runserver``
6. go to ``127.0.0.1:8000/admin`` and login with your superuser credentials. you should get a first basic wagtail impression now :)

Closes: #6