### PR TITLE
[#20] Remove Django from 'constrains.pip'

### DIFF
--- a/requirements/constraints.pip
+++ b/requirements/constraints.pip
@@ -1,3 +1,2 @@
 # This file controls which version of a requirement is installed.
 
-Django==1.8.14  # rq.filter: <1.9


### PR DESCRIPTION
As we do not really know why django should be in there we remove it from
our constrains file.

Ref: #20